### PR TITLE
Implementing splitAt, take and drop with unit tests.

### DIFF
--- a/sosa.ml
+++ b/sosa.ml
@@ -196,6 +196,19 @@ module type BASIC_STRING = sig
   val slice_exn: ?start:int -> ?finish:int -> t -> t
   (** Like [slice] but throw an exception instead of returning [None] *)
 
+  val split_at: t -> int -> t * t
+  (** Return a tuple where the first string is a prefix of the specified length
+      and the second is the rest. If index is [=< 0] then the first element is
+      empty and the string is returned in the second element, similarly if the
+      index is [>= length t] then the first element is [t] and the second is
+      [empty]. *)
+
+  val take: t -> int -> t
+  (** Just the first part of split_at *)
+
+  val drop: t -> int -> t
+  (** Just the second part of split_at *)
+
   val compare_substring: t * int * int -> t * int * int -> int
   (** Comparison function for substrings: use as [compare_substring
       (s1, index1, length1) (s2, index2, length2)].
@@ -722,6 +735,36 @@ module Make_strip_function (S:
     | Not_found -> empty
 end
 
+module Make_split_at_index_functions (A:
+    sig
+      type t
+      type character
+      val empty : t
+      val length : t -> int
+      val sub_exn : t -> index:int -> length:int -> t
+    end) = struct
+
+  let split_at t n =
+    let l = A.length t in
+    if n < 0 then (A.empty, t)
+    else if n >= l then (t, A.empty)
+         else (A.sub_exn t ~index:0 ~length:n),
+              (A.sub_exn t ~index:n ~length:(l - n))
+
+  let take t n =
+    let l = A.length t in
+    if n < 0 then A.empty
+    else if n >= l then t
+         else A.sub_exn t ~index:0 ~length:n
+
+  let drop t n =
+    let l = A.length t in
+    if n < 0 then t
+    else if n >= l then A.empty
+         else (A.sub_exn t ~index:n ~length:(l - n))
+
+
+  end
 module Native_string : NATIVE_STRING = struct
 
   include StringLabels
@@ -981,6 +1024,14 @@ module Native_string : NATIVE_STRING = struct
       let index_of_character = index_of_character
     end)
 
+  include Make_split_at_index_functions(struct
+      type t = string
+      type character = char
+      let empty = empty
+      let length = length
+      let sub_exn = sub_exn
+    end)
+
   module Make_output (Model: OUTPUT_MODEL) = Model
 
 end
@@ -1174,6 +1225,28 @@ module List_of (Char: BASIC_CHARACTER) :
   let slice ?start ?finish t =
     try Some (slice_exn ?start ?finish t)
     with _ -> None
+
+  let unrevSplit t n =
+    if n < 0
+    then [],t
+    else let rec offset i ((l,r) as p) =
+           if i = n
+           then p
+           else match r with
+                | []   -> p
+                | h::t -> offset (i + 1) (h::l,t)
+         in
+         offset 0 ([],t)
+
+  let split_at t n =
+    let l,r = unrevSplit t n in
+    List.rev l, r
+
+  let take t n = fst (split_at t n)
+
+  let drop t n =
+    let l,r = unrevSplit t n in
+    r
 
   let index_of_character t ?(from=0) c =
     let index = ref 0 in
@@ -1753,6 +1826,15 @@ module Of_mutable
       let index_of_string = index_of_string
       let index_of_character = index_of_character
     end)
+
+  include Make_split_at_index_functions(struct
+      type t = S.t
+      type character = S.character
+      let empty = empty
+      let length = length
+      let sub_exn t ~index ~length = sub_exn t index length
+    end)
+
 
   module Make_output (Model: OUTPUT_MODEL) = struct
 

--- a/test/sosa_test.ml
+++ b/test/sosa_test.ml
@@ -1163,6 +1163,33 @@ let do_basic_test (module Test : TEST_STRING) =
     test 10000;    (* to cover that slow case *)
   end;
 
+  begin (* Test split_at, take and drop. *)
+    let test l n (le,ri) =
+      let s   = ints_to_str l
+      and le' = ints_to_str le
+      and ri' = ints_to_str ri in
+      let (rl,rr) as res = Str.split_at s n
+      and tres  = Str.take s n
+      and dres  = Str.drop s n in
+      test_assertf (res = (le',ri') && tres = le' && dres = ri')
+        "split_at: %s %d expects (%s,%s) but got (%s,%s)"
+          (int_list_to_string l)
+          n
+          (int_list_to_string le)
+          (int_list_to_string ri)
+          (Str.to_native_string rl)
+          (Str.to_native_string rr)
+    in
+    test []      (-1) ([],[]);
+    test []      (0)  ([],[]);
+    test []      (1)  ([],[]);
+    test [1;2;3] (-1) ([],[1;2;3]);
+    test [1;2;3] (0)  ([],[1;2;3]);
+    test [1;2;3] (1)  ([1],[2;3]);
+    test [1;2;3] (2)  ([1;2],[3]);
+    test [1;2;3] (3)  ([1;2;3],[]);
+    test [1;2;3] (4)  ([1;2;3],[]);
+  end;
 
   (* #### BENCHMARKS #### *)
 


### PR DESCRIPTION
splitAt -> split_at
different functor name
and boundary documentation.
