### PR TITLE
Fix map & mapi

### DIFF
--- a/sosa.ml
+++ b/sosa.ml
@@ -1806,7 +1806,7 @@ module Of_mutable
     then empty
     else begin
       let res = make lgth (S.get t 0) in
-      for i = 1 to lgth - 1 do
+      for i = 0 to lgth - 1 do
         S.set res i (f (S.get t i))
       done;
       res


### PR DESCRIPTION
There were indexing issues that tests didn't catch for `mapi` (and there were no tests for `map`), so I fixed the bug and added tests.

Bug was e.g. 

``` ocaml
map ~f:(fun x -> x + 1) [1;2;3]
(* => [1;3;4] *)
```

Because the first indexed element was being skipped.
