### PR TITLE
The great split

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ BISECT_DIR=$(shell ocamlfind query bisect)
 default:
 	@echo "available targets:"
 	@echo "  build        compile sosa"
+	@echo "  test	        compile sosa_tests, a test suite"
 	@echo "  coverage     compile sosa with instrumented bisect_ppx coverage"
 	@echo "  cov_report   create a coverage report from the latest coverage run"
 	@echo "  clean        remove build directory"


### PR DESCRIPTION
This PR is about splitting the code into somewhat coherent code fragments. There are a couple of things that still look awkward as a result, such as `Conversions` in `Sosa_utilities`. I think we should probably refactor that away somehow. It currently isn't documented and I left it that way.

I also want to avoid the move to refining the API to `bytes` and `strings`.

This fixes #38