### PR TITLE
Overwrite native types in functors

### DIFF
--- a/.ocamlinit
+++ b/.ocamlinit
@@ -1,0 +1,3 @@
+
+#directory "_build/src/lib" ;;
+#load_rec "sosa.cma" ;;

--- a/src/lib/api.mli
+++ b/src/lib/api.mli
@@ -433,14 +433,14 @@ module type UNSAFELY_MUTABLE = sig
 end (* UNSAFELY_MUTABLE *)
 
 (** Native {i OCaml} character. *)
-module type NATIVE_CHARACTER = BASIC_CHARACTER with type t = char
+module type NATIVE_CHARACTER = BASIC_CHARACTER with type t := char
 
 (** Native {i OCaml} string. *)
 module type NATIVE_STRING = sig
 
   include BASIC_STRING
-    with type t = String.t
-    with type character = char
+    with type t := string
+    with type character := char
 
 end (* NATIVE_STRING *)
 
@@ -448,11 +448,11 @@ end (* NATIVE_STRING *)
 module type NATIVE_BYTES = sig
 
   include BASIC_STRING
-    with type t = Bytes.t
-    with type character = char
+    with type t := bytes
+    with type character := char
 
   include UNSAFELY_MUTABLE
-    with type t := Bytes.t
+    with type t := bytes
     with type character := char
 
 end (* NATIVE_BYTES *)

--- a/src/lib/api.mli
+++ b/src/lib/api.mli
@@ -433,10 +433,16 @@ module type UNSAFELY_MUTABLE = sig
 end (* UNSAFELY_MUTABLE *)
 
 (** Native {i OCaml} character. *)
-module type NATIVE_CHARACTER = BASIC_CHARACTER with type t := char
+module type NATIVE_CHARACTER = sig
+  type t = char
+  include BASIC_CHARACTER with type t := char
+end
 
 (** Native {i OCaml} string. *)
 module type NATIVE_STRING = sig
+
+  type character = char
+  type t = string
 
   include BASIC_STRING
     with type t := string
@@ -446,6 +452,9 @@ end (* NATIVE_STRING *)
 
 (** Native {i OCaml} byte. *)
 module type NATIVE_BYTES = sig
+
+  type character = char
+  type t = bytes
 
   include BASIC_STRING
     with type t := bytes


### PR DESCRIPTION
@smondet  This might be a contentious PR, but I find the type signatures slightly easier to see.
```OCaml
val index_of_string : ?from:int -> ?sub_index:int -> ?sub_length:int -> bytes -> sub:bytes -> int option
```
vs
```OCaml
val index_of_string : ?from:int -> ?sub_index:int -> ?sub_length:int -> Bytes.t -> sub:Bytes.t -> int option
```